### PR TITLE
去掉冗余代码和添加自定义的review提示词文件

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -118,8 +118,25 @@ pub async fn review_changes(config: &Config, no_review: bool) -> Result<Option<S
 
 // 构建代码审查提示语
 fn get_review_prompt() -> String {
-    format!(
-        r#"您是一位专业的代码审查者，请对以下代码变更进行审查并给出中文评价。请着重关注：
+    // 获取配置文件路径
+    let prompt_path = crate::config::Config::config_path()
+        .expect("无法获取配置目录")
+        .parent()
+        .expect("无法获取父目录")
+        .join("review_prompt.txt");
+
+    // 如果文件存在则读取，否则使用默认提示语
+    if prompt_path.exists() {
+        info!("正在使用 {:?} 提示词文件, 进行代码审查...", prompt_path.display());
+        std::fs::read_to_string(prompt_path).unwrap_or_else(|_| {
+            DEFAULT_REVIEW_PROMPT.to_string()
+        })
+    } else {
+        DEFAULT_REVIEW_PROMPT.to_string()
+    }
+}
+
+const DEFAULT_REVIEW_PROMPT:&str = r#"您是一位专业的代码审查者，请对以下代码变更进行审查并给出中文评价。请着重关注：
 
 1. 代码质量：
    - 代码是否清晰易懂
@@ -149,8 +166,7 @@ fn get_review_prompt() -> String {
    - 权限检查
 
 请以"代码审查报告："开头，使用简洁的语言描述发现的问题和改进建议。如果代码符合最佳实践，也请给出正面的评价。
-"#)
-}
+"#;
 
 fn get_staged_changes() -> Result<String> {
     let output = Command::new("git")

--- a/src/review.rs
+++ b/src/review.rs
@@ -106,13 +106,6 @@ pub async fn review_changes(config: &Config, no_review: bool) -> Result<Option<S
         return Ok(None);
     }
 
-    // 获取当前改动的差异
-    let diff = get_staged_changes()?;
-    if diff.trim().is_empty() {
-        info!("没有检测到暂存的代码改动");
-        return Ok(None);
-    }
-
     // 使用配置的 AI 服务进行代码审查
     let translator = ai_service::create_translator(config).await?;
     info!("正在使用 {:?} 服务进行代码审查...", config.default_service);


### PR DESCRIPTION
1、去掉冗余代码
2、添加自定义的review提示词文件：~/.config/git-commit-helper/review_prompt.txt