### PR TITLE
docs: fix markdown table formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ git-commit-helper translate /path/to/existing/file    # 文件路径
 
 | 命令 | 说明 | 示例 |
 |------|------|------|
-| config | 配置 AI 服务 | `git-commit-helper config [--set-only-chinese <true|false>]` |
+| config | 配置 AI 服务 | `git-commit-helper config [--set-only-chinese <true\|false>]` |
 | show | 显示当前配置 | `git-commit-helper show` |
 | install | 安装 Git Hook | `git-commit-helper install [-f]` |
 | ai add | 添加 AI 服务 | `git-commit-helper ai add` |


### PR DESCRIPTION
Fixed the markdown table formatting in README.md by properly escaping the pipe character in the command example. The unescaped pipe was causing rendering issues in some markdown parsers. This ensures consistent display across different platforms and tools.

修复了 README.md 中表格格式问题，正确转义了命令示例中的管道字符。未转义
的管道字符在某些 Markdown 解析器中会导致渲染问题。此修改确保了在不同平台
和工具中的显示一致性。