### PR TITLE
feat: 添加仅英文提交信息支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ git-commit-helper translate /path/to/existing/file    # 文件路径
 
 | 命令 | 说明 | 示例 |
 |------|------|------|
-| config | 配置 AI 服务 | `git-commit-helper config [--set-only-chinese <true\|false>]` |
+| config | 配置 AI 服务 | `git-commit-helper config [--set-only-chinese <true\|false>/--set-only-english <true\|false>]` |
 | show | 显示当前配置 | `git-commit-helper show` |
 | install | 安装 Git Hook | `git-commit-helper install [-f]` |
 | ai add | 添加 AI 服务 | `git-commit-helper ai add` |
@@ -189,7 +189,7 @@ git-commit-helper translate /path/to/existing/file    # 文件路径
 | ai list | 列出所有服务 | `git-commit-helper ai list` |
 | ai test | 测试指定服务 | `git-commit-helper ai test [-t "测试文本"]` |
 | translate | 翻译内容 | `git-commit-helper translate [-f 文件] [-t 文本]` |
-| commit | 生成提交信息 | `git-commit-helper commit [-t 类型] [-m 描述] [-a] [--no-review]` |
+| commit | 生成提交信息 | `git-commit-helper commit [-t 类型] [-m 描述] [-a] [--no-review/--only-chinese/--only-english]` |
 | ai-review | 管理 AI 代码审查 | `git-commit-helper ai-review [--enable/--disable/--status]` |
 
 ### 提交类型
@@ -235,9 +235,11 @@ git-commit-helper commit [选项]
     -a, --all                 自动添加所有已修改但未暂存的文件
     --no-review              禁用当前提交的代码审查功能
     --only-chinese           仅保留中文提交信息
+    --only-english           仅保留英文提交信息
 ```
 
 示例：
+
 ```bash
 # 生成提交信息
 git-commit-helper commit
@@ -256,10 +258,18 @@ git-commit-helper commit --type fix --message "修复内存泄漏" -a
 
 # 设置默认使用中文
 git-commit-helper config --set-only-chinese true   # 默认仅使用中文
-git-commit-helper config --set-only-chinese false  # 默认使用中英双语
+
+# 设置默认使用英文
+git-commit-helper config --set-only-english true   # 默认仅使用英文
+
+# 设置默认使用中英双语
+git-commit-helper config --set-only-chinese false --set-only-english false  # 默认使用中英双语
 
 # 单次提交使用中文
 git-commit-helper commit --type feat --message "添加新功能" --only-chinese
+
+# 单次提交使用英文
+git-commit-helper commit --type feat --message "Add new functions" --only-english
 ```
 
 ### AI 代码审查功能
@@ -305,7 +315,7 @@ git-commit-helper https://gerrit.example.com/c/project/+/123456
 ```
 
 输出格式：
-```
+```txt
 标题：<原始标题>
 中文翻译：<标题翻译>
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,10 +24,16 @@ pub struct Config {
     pub gerrit: Option<GerritConfig>,  // Gerrit 配置
     #[serde(default = "default_only_chinese")]
     pub only_chinese: bool,  // 是否默认只使用中文
+    #[serde(default = "default_only_english")]
+    pub only_english: bool,  // 是否默认只使用英文
 }
 
 // 添加默认值函数
 fn default_only_chinese() -> bool {
+    false
+}
+
+fn default_only_english() -> bool {
     false
 }
 
@@ -82,6 +88,7 @@ impl Config {
             max_tokens: default_max_tokens(),
             gerrit: None,
             only_chinese: false,  // 默认关闭
+            only_english: false,  // 默认关闭
         }
     }
 
@@ -279,6 +286,7 @@ impl Config {
             max_tokens: default_max_tokens(),
             gerrit: None,
             only_chinese: false,  // 默认关闭
+            only_english: false,  // 默认关闭
         };
 
         // 确保配置目录存在
@@ -307,6 +315,7 @@ impl Config {
                 max_tokens: config.max_tokens,
                 gerrit: None,
                 only_chinese: false,
+                only_english: false,
             };
             let translator = ai_service::create_translator(&test_config).await?;
             match translator.translate("这是一个测试消息，用于验证翻译功能是否正常。").await {
@@ -480,6 +489,7 @@ impl Config {
                 max_tokens: self.max_tokens,
                 gerrit: None,
                 only_chinese: false,
+                only_english: false,
             };
             let translator = ai_service::create_translator(&test_config).await?;
             let text = "这是一个测试消息，用于验证翻译功能是否正常。";


### PR DESCRIPTION
feat: 添加仅英文提交信息支持
1. 添加 `only_english` 配置选项以补充现有的 `only_chinese` 设置
2. 实现冲突解决机制，其中 `only_english` 优先级高于 `only_chinese`
3. 更新提示生成以支持三种语言模式：仅英文、仅中文和双语
4. 为 commit 命令添加 `--only-english` 命令行参数
5. 扩展配置管理以处理新的仅英文设置
6. 更新状态显示以显示当前语言模式（仅英文/仅中文/双语）

refactor: 重构提交消息提示词生成系统
使用枚举驱动架构替换复杂的匹配模式处理，提高可维护性。添加 LanguageMode枚举来管理英文、中文和双语消息生成模式。将提示词模板提取为常量，创建统一的 build_prompt 函数以消除代码重复并提高可读性。

docs: 更新语言选项的CLI文档
1. 为config和commit命令添加--only-english标志
2. 更新命令表格以显示新的语言配置选项
3. 添加仅英文提交生成的示例
4. 澄清双语与单语配置
5. 修复输出示例的代码块格式