### PR TITLE
feat: add --amend option for commit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ git-commit-helper translate /path/to/existing/file    # 文件路径
 | ai list | 列出所有服务 | `git-commit-helper ai list` |
 | ai test | 测试指定服务 | `git-commit-helper ai test [-t "测试文本"]` |
 | translate | 翻译内容 | `git-commit-helper translate [-f 文件] [-t 文本]` |
-| commit | 生成提交信息 | `git-commit-helper commit [-t 类型] [-m 描述] [-a] [--no-review/--no-influence/--no-log/--only-chinese/--only-english] [--issues ISSUE...]` |
+| commit | 生成提交信息 | `git-commit-helper commit [-t 类型] [-m 描述] [-a] [--amend] [--no-review/--no-influence/--no-log/--only-chinese/--only-english] [--issues ISSUE...]` |
 | ai-review | 管理 AI 代码审查 | `git-commit-helper ai-review [--enable/--disable/--status]` |
 
 ### 提交类型
@@ -304,6 +304,10 @@ git-commit-helper commit --issues "https://pms.uniontech.com/story-view-38949.ht
 # 混合关联
 git-commit-helper commit --issues "123" "https://pms.uniontech.com/bug-view-320461.html"
 git-commit-helper commit --issues "https://github.com/owner/repo/issues/123" "https://pms.uniontech.com/task-view-374223.html"
+
+# 修补上次提交
+git-commit-helper commit --amend
+git-commit-helper commit --amend --only-chinese
 ```
 
 ### AI 代码审查功能

--- a/src/git.rs
+++ b/src/git.rs
@@ -102,6 +102,36 @@ fn contains_chinese(text: &str) -> bool {
     text.chars().any(|c| c as u32 >= 0x4E00 && c as u32 <= 0x9FFF)
 }
 
-pub fn wrap_text(text: &str, max_length: usize) -> String {
-    fill(text, max_length)
+pub fn wrap_text(text: &str, width: usize) -> String {
+    fill(text, width)
+}
+
+/// 获取上一次提交的差异内容，用于 amend 模式
+pub fn get_last_commit_diff() -> anyhow::Result<String> {
+    use std::process::Command;
+    
+    let output = Command::new("git")
+        .args(["diff", "HEAD~1..HEAD", "--no-prefix"])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!("执行 git diff HEAD~1..HEAD 命令失败，可能没有足够的提交历史"));
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// 获取上一次提交的信息
+pub fn get_last_commit_message() -> anyhow::Result<String> {
+    use std::process::Command;
+    
+    let output = Command::new("git")
+        .args(["log", "-1", "--pretty=format:%s%n%n%b"])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!("执行 git log 命令失败"));
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,9 @@ enum Commands {
         /// 自动添加所有已修改但未暂存的文件
         #[arg(short, long)]
         all: bool,
+        /// 修改上一次提交信息
+        #[arg(long)]
+        amend: bool,
         /// 不翻译提交信息
         #[arg(long)]
         no_translate: bool,
@@ -413,13 +416,13 @@ async fn main() -> Result<()> {
                 Err(e) => Err(e)
             }
         }
-        Some(Commands::Commit { r#type, message, all, no_translate, only_chinese, only_english, no_influence, no_log, issues }) => {
+        Some(Commands::Commit { r#type, message, all, amend, no_translate, only_chinese, only_english, no_influence, no_log, issues }) => {
             let issues_str = if issues.is_empty() {
                 None
             } else {
                 Some(issues.join(" "))
             };
-            commit::generate_commit_message(r#type, message, all, cli.no_review, no_translate, only_chinese, only_english, no_influence, no_log, issues_str).await
+            commit::generate_commit_message(r#type, message, all, amend, cli.no_review, no_translate, only_chinese, only_english, no_influence, no_log, issues_str).await
         }
         Some(Commands::AIReview { enable, disable, status }) => {
             let mut config = config::Config::load()?;


### PR DESCRIPTION
1. Added --amend flag to modify the last commit instead of creating a new one
2. Implemented logic to fetch diff from last commit when in amend mode
3. Added display of original commit message for reference during amend
4. Modified git command execution to include --amend flag when appropriate
5. Added proper error handling for amend mode when no commit history exists
6. Updated help documentation to include the new --amend option
7. Skip AI code review for amend operations since it's modifying existing commit

Log: Added --amend option to modify last commit with new commit message

Influence:
1. Test normal commit functionality to ensure no regression
2. Test --amend option with staged changes to modify last commit
3. Test --amend option with other flags like --only-chinese
4. Verify error handling when no commit history exists for amend
5. Test amend with different commit types and messages
6. Verify that original commit message is displayed correctly
7. Ensure AI code review is skipped for amend operations

feat: 为 commit 命令添加 --amend 选项

1. 添加 --amend 标志用于修改上一次提交而不是创建新提交
2. 实现在 amend 模式下从上次提交获取差异内容的逻辑
3. 添加在 amend 时显示原提交信息供参考的功能
4. 修改 git 命令执行以在适当时包含 --amend 标志
5. 为 amend 模式添加适当的错误处理，当没有提交历史时
6. 更新帮助文档以包含新的 --amend 选项
7. 为 amend 操作跳过 AI 代码审查，因为是修改现有提交

Log: 新增 --amend 选项用于使用新提交信息修改上次提交

Influence:
1. 测试正常提交功能以确保没有回归
2. 测试 --amend 选项与暂存更改一起使用来修改上次提交
3. 测试 --amend 选项与其他标志如 --only-chinese 的组合使用
4. 验证当没有提交历史时 amend 的错误处理
5. 测试使用不同提交类型和消息的 amend 操作
6. 验证原提交信息是否正确显示
7. 确保 AI 代码审查在 amend 操作中被跳过